### PR TITLE
Google Tag Managerタグを追加

### DIFF
--- a/b/index.html
+++ b/b/index.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N6H8FT3M');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>無理に頑張らなくていい。水のように、自然に生きる - 老荘思想が教える生きやすさのヒント</title>
@@ -8,6 +15,10 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6H8FT3M"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <!-- ファーストビュー -->
     <section id="hero" class="hero">
         <div class="hero-background">

--- a/b/thanks.html
+++ b/b/thanks.html
@@ -1,6 +1,13 @@
 <!DOCTYPE html>
 <html lang="ja">
 <head>
+    <!-- Google Tag Manager -->
+    <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-N6H8FT3M');</script>
+    <!-- End Google Tag Manager -->
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>ありがとうございます - 老荘思想ガイド</title>
@@ -240,6 +247,10 @@
     </style>
 </head>
 <body>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-N6H8FT3M"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
     <div class="thank-you-container">
         <div class="thank-you-icon">🙏</div>
         <h1 class="thank-you-title">ありがとうございます</h1>


### PR DESCRIPTION
## 概要
Google Tag Manager (GTM-N6H8FT3M) のタグをb/ディレクトリのHTMLファイルに追加しました。

## 変更内容
- ✅ **b/index.html**: GTMタグを追加
- ✅ **b/thanks.html**: GTMタグを追加

## 実装詳細
各HTMLファイルに以下の2つのタグを追加：

1. **`<head>`内の最上部**
   - GTMスクリプトタグを配置
   - Googleの公式推奨に従い、できるだけ早く読み込まれるように配置

2. **`<body>`開始タグ直後**
   - noscriptタグを配置
   - JavaScriptが無効な環境でもトラッキングできるようにフォールバック

## 注意事項
⚠️ GTMタグを`<head>`の最上部に配置したため、`charset` metaタグが最初に来ていないという診断警告が出ています。これはGoogleの公式推奨配置に従った結果であり、意図的な実装です。

## テスト
- [x] ローカル環境でHTMLファイルが正常に表示されることを確認
  - ✅ b/index.html: GTM scriptタグとnoscriptタグを確認
  - ✅ b/thanks.html: GTM scriptタグとnoscriptタグを確認
  - ✅ Playwright自動テストですべてパス
- [ ] Google Tag Manager管理画面でタグの動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)