### PR TITLE
feat: Google広告サイトリンク用に書籍紹介セクションとセルフケアセクションを追加

### DIFF
--- a/b/index.html
+++ b/b/index.html
@@ -158,6 +158,86 @@
         </div>
     </section>
 
+    <!-- 書籍紹介セクション -->
+    <section id="books" class="books-section">
+        <div class="container">
+            <h2 class="section-title">もっと学びたい方へ</h2>
+            <p class="section-intro">
+                老荘思想をより深く理解するための書籍をご紹介します。<br>
+                初心者の方にもわかりやすい入門書から、原典に触れられる本まで。
+            </p>
+
+            <div class="books-grid">
+                <div class="book-card">
+                    <div class="book-icon">📖</div>
+                    <h3 class="book-title">あるがままの生き方のススメ<br>老荘思想がよくわかる本</h3>
+                    <p class="book-author">金谷治（新人物文庫）</p>
+                    <p class="book-description">老荘思想の基本をわかりやすく解説。初心者におすすめの一冊です。</p>
+                    <a href="https://www.amazon.co.jp/%E3%81%82%E3%82%8B%E3%81%8C%E3%81%BE%E3%81%BE%E3%81%AE%E7%94%9F%E3%81%8D%E6%96%B9%E3%81%AE%E3%82%B9%E3%82%B9%E3%83%A1-%E8%80%81%E8%8D%98%E6%80%9D%E6%83%B3%E3%81%8C%E3%82%88%E3%81%8F%E3%82%8F%E3%81%8B%E3%82%8B%E6%9C%AC-%E6%96%B0%E4%BA%BA%E7%89%A9%E6%96%87%E5%BA%AB-%E9%87%91%E8%B0%B7-%E6%B2%BB-ebook/dp/B00MB2SUP2/" target="_blank" rel="noopener" class="book-link">書籍を見る →</a>
+                </div>
+
+                <div class="book-card">
+                    <div class="book-icon">📚</div>
+                    <h3 class="book-title">新釈 荘子</h3>
+                    <p class="book-author">西野広祥（PHP文庫）</p>
+                    <p class="book-description">荘子の思想を現代語でわかりやすく解説した入門書です。</p>
+                    <a href="https://www.amazon.co.jp/%E6%96%B0%E9%87%88-%E8%8D%98%E5%AD%90-PHP%E6%96%87%E5%BA%AB-%E8%A5%BF%E9%87%8E-%E5%BA%83%E7%A5%A5-ebook/dp/B00878HGSG/" target="_blank" rel="noopener" class="book-link">書籍を見る →</a>
+                </div>
+
+                <div class="book-card">
+                    <div class="book-icon">📗</div>
+                    <h3 class="book-title">老子</h3>
+                    <p class="book-author">金谷治（講談社学術文庫）</p>
+                    <p class="book-description">老子の原典を丁寧に解説。より深く学びたい方におすすめです。</p>
+                    <a href="https://www.amazon.co.jp/%E8%80%81%E5%AD%90-%E8%AC%9B%E8%AB%87%E7%A4%BE%E5%AD%A6%E8%A1%93%E6%96%87%E5%BA%AB-%E9%87%91%E8%B0%B7%E6%B2%BB-ebook/dp/B0CGR5VRGP/" target="_blank" rel="noopener" class="book-link">書籍を見る →</a>
+                </div>
+            </div>
+        </div>
+    </section>
+
+    <!-- セルフケアセクション -->
+    <section id="selfcare" class="selfcare-section">
+        <div class="container">
+            <h2 class="section-title">今すぐできるセルフケア</h2>
+            <p class="section-intro">
+                老荘思想に基づく、日常で実践できるセルフケアの方法をご紹介します。<br>
+                無理をせず、自然に自分の心を整えていきましょう。
+            </p>
+
+            <div class="selfcare-grid">
+                <div class="selfcare-item">
+                    <div class="selfcare-icon">🌬️</div>
+                    <h3>深呼吸で心を整える</h3>
+                    <p>深く息を吸い、ゆっくりと吐く。ただそれだけで、心は自然と落ち着きます。無為自然の考え方です。</p>
+                </div>
+
+                <div class="selfcare-item">
+                    <div class="selfcare-icon">🌿</div>
+                    <h3>自然に触れる時間を持つ</h3>
+                    <p>公園を散歩したり、空を眺めたり。自然の中にいると、心がリセットされます。</p>
+                </div>
+
+                <div class="selfcare-item">
+                    <div class="selfcare-icon">📱</div>
+                    <h3>デジタルから離れる</h3>
+                    <p>スマホやSNSから一時的に離れる時間を作りましょう。情報に追われない静かな時間が大切です。</p>
+                </div>
+
+                <div class="selfcare-item">
+                    <div class="selfcare-icon">🏠</div>
+                    <h3>シンプルに暮らす</h3>
+                    <p>必要最小限のものだけで十分。老子の「小国寡民」のように、シンプルな生活に満足を見つけましょう。</p>
+                </div>
+
+                <div class="selfcare-item">
+                    <div class="selfcare-icon">⏰</div>
+                    <h3>自分のペースを守る</h3>
+                    <p>他人のスピードに合わせる必要はありません。水のように、自分の流れを大切にしましょう。</p>
+                </div>
+            </div>
+        </div>
+    </section>
+
     <!-- 相談窓口セクション（重要） -->
     <section id="support" class="support-section">
         <div class="container">

--- a/b/styles.css
+++ b/b/styles.css
@@ -395,6 +395,130 @@ body {
 }
 
 /* ========================================
+   書籍紹介セクション
+   ======================================== */
+.books-section {
+    padding: 80px 0;
+    background: #f5f3f0;
+}
+
+.books-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+    gap: 2.5rem;
+}
+
+.book-card {
+    background: #fafaf8;
+    border: 1px solid #e6e3dc;
+    border-radius: 0;
+    padding: 2.5rem 2rem;
+    text-align: center;
+    transition: all 0.4s ease;
+    position: relative;
+}
+
+.book-card:hover {
+    background: #ebe9e4;
+    box-shadow: 0 2px 8px rgba(90, 106, 111, 0.1);
+}
+
+.book-icon {
+    font-size: 3.5rem;
+    margin-bottom: 1.5rem;
+    opacity: 0.9;
+}
+
+.book-title {
+    font-size: 1.2rem;
+    color: #4a5759;
+    margin-bottom: 1rem;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    line-height: 1.8;
+}
+
+.book-author {
+    font-size: 0.95rem;
+    color: #7a9299;
+    margin-bottom: 1.2rem;
+    font-weight: 300;
+    letter-spacing: 0.05em;
+}
+
+.book-description {
+    font-size: 0.95rem;
+    color: #5a6a6f;
+    line-height: 2;
+    margin-bottom: 1.5rem;
+    letter-spacing: 0.03em;
+}
+
+.book-link {
+    display: inline-block;
+    color: #7a9299;
+    text-decoration: none;
+    font-weight: 500;
+    margin-top: 1rem;
+    transition: color 0.3s ease;
+    letter-spacing: 0.05em;
+}
+
+.book-link:hover {
+    color: #6a8289;
+}
+
+/* ========================================
+   セルフケアセクション
+   ======================================== */
+.selfcare-section {
+    padding: 80px 0;
+    background-color: #fafaf8;
+}
+
+.selfcare-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2.5rem;
+}
+
+.selfcare-item {
+    padding: 2.5rem 2rem;
+    background: #f5f3f0;
+    border: 1px solid #e6e3dc;
+    border-radius: 0;
+    position: relative;
+    transition: all 0.4s ease;
+    text-align: center;
+}
+
+.selfcare-item:hover {
+    background: #ebe9e4;
+    box-shadow: 0 2px 8px rgba(90, 106, 111, 0.1);
+}
+
+.selfcare-icon {
+    font-size: 3rem;
+    margin-bottom: 1.2rem;
+    opacity: 0.9;
+}
+
+.selfcare-item h3 {
+    margin-bottom: 1rem;
+    color: #4a5759;
+    font-weight: 500;
+    letter-spacing: 0.05em;
+    font-size: 1.1rem;
+}
+
+.selfcare-item p {
+    color: #5a6a6f;
+    line-height: 2;
+    letter-spacing: 0.03em;
+    font-size: 0.95rem;
+}
+
+/* ========================================
    相談窓口セクション
    ======================================== */
 .support-section {
@@ -688,6 +812,14 @@ body {
     }
 
     .practice-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .books-grid {
+        grid-template-columns: 1fr;
+    }
+
+    .selfcare-grid {
         grid-template-columns: 1fr;
     }
 }


### PR DESCRIPTION
## 概要
Google広告のサイトリンク拡張に対応するため、書籍紹介セクションとセルフケアセクションを追加しました。

## 変更内容
- サイトリンク用の新しいセクションを追加
- 書籍紹介セクションの実装
- セルフケアセクションの実装

## 関連
コミット: 5ccd992